### PR TITLE
Fixed visualization bug and modify scripts to handle large file exceed github limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- We fixed bugs in visualization scripts
 
 ## [0.1.2] - 2024-03-15
 ### Added
@@ -47,4 +49,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [0.0.11]: https://github.com/rubykong/cbig_network_correspondence/compare/0.0.10...0.0.11
 [0.0.10]: https://github.com/rubykong/cbig_network_correspondence/compare/0.0.9...0.0.10
 [0.0.9]: https://github.com/rubykong/cbig_network_correspondence/tree/0.0.9
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cbig_network_correspondence"
-version = "0.1.2"
+version = "0.1.3"
 description = "A toolbox for exploring network correspondence across atlases"
 authors = [
     "Ruby Kong <roo.cone@gmail.com>",
@@ -37,6 +37,10 @@ scipy = "^1.9.0"
 seaborn = "^0.11.2"
 gitpython = "^3.1.27"
 brainspace = "^0.1.10"
+pandas = "^1.3.2"
+colorcet = "^3.0.1"
+plottable = "^0.1.5"
+regfusion = "^0.1.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "*"

--- a/src/cbig_network_correspondence/__init__.py
+++ b/src/cbig_network_correspondence/__init__.py
@@ -5,6 +5,27 @@ from . import visualize_report_lib
 import os
 os.environ["GIT_PYTHON_REFRESH"] = "quiet"
 from git import Repo
+import gzip
+import shutil
+
+def concatenate_files(file_path, num_parts, output_file):
+    with open(output_file, 'wb') as f_out:
+        for part_number in range(1, num_parts + 1):
+            input_file = f'{file_path}.part{part_number}'
+            with open(input_file, 'rb') as f_in:
+                shutil.copyfileobj(f_in, f_out)
+
+def unzip_model(file_path):
+    # Decompress the compressed model
+    with gzip.open(file_path + ".gz", 'rb') as f_in:
+        with open(file_path, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+def combine_model(data_space, num_parts):
+    compressed_file = os.path.join(data_dir, 'spin_rotations', data_space, '1000_spin_permutations_state0.pkl.gz')
+    out_file = compressed_file.replace('.gz', '')
+    concatenate_files(compressed_file, num_parts, compressed_file)
+    unzip_model(out_file)
 
 data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 if not os.path.exists(data_dir):
@@ -13,3 +34,7 @@ if not os.path.exists(data_dir):
 else:
     repo_dir = Repo(data_dir)
     repo_dir.remotes.origin.pull('master')
+
+combine_model('fs_LR_32k', 3)
+combine_model('fsaverage6', 5)
+

--- a/src/cbig_network_correspondence/grab_data_info.py
+++ b/src/cbig_network_correspondence/grab_data_info.py
@@ -105,6 +105,7 @@ def check_args_format(args):
                          "e.g., probability map, task contrast map.")
     if args.netassign is None:
         print("Data_NetworkAssignment is not specified.")
+        args.netassign = False
     if args.threshold is None:
         if args.type == 'Soft':
             args.threshold = thresh_str_to_num('[0, Inf]')

--- a/src/cbig_network_correspondence/visualize_report_lib.py
+++ b/src/cbig_network_correspondence/visualize_report_lib.py
@@ -12,6 +12,7 @@ from plottable.plots import bar, percentile_bars, percentile_stars, progress_don
 from plottable.cmap import normed_cmap
 from plottable.plots import circled_image # image
 from pandas.plotting import table
+import os
 
 
 def dice_percent(val: float) -> str:
@@ -183,6 +184,12 @@ def scale_fontsize(x, groups, low=12, high=20):
     return sc
 
 def circular_barchart(df,group_names,group_names_full,p_threshold=0.05):
+    # if group_names is a list, change it to numpy array
+    if type(group_names) == list:
+        group_names = np.array(group_names)
+    # if group_names_full is a list, change it to numpy array
+    if type(group_names_full) == list:
+        group_names_full = np.array(group_names_full)
     # All this part is like the code above
     for group in group_names:
         curr_VALUES = df[df["group"]==group]["dice"].values * 100
@@ -289,6 +296,8 @@ def circular_barchart(df,group_names,group_names_full,p_threshold=0.05):
         handlelength=1,
         handleheight=1,
         handletextpad=0.2,columnspacing=0.7)
+
+    return fig
     
 def circular_subplot(ax,VALUES, LABELS,PVALUE,COLORS,Group,p_threshold=0.05):
     # All this part is like the code above
@@ -424,6 +433,7 @@ def circular_atlases_all(df,group_names,p_threshold=0.05):
 
         circular_subplot(ax,VALUES, LABELS,PVALUE,COLORS,idx+1)
     fig.subplots_adjust(wspace=2, hspace=1.1)
+    return fig
 
 def table_summary_plot(df,atlas_names_list, atlas_names_list_full):
     fig = {}
@@ -615,3 +625,25 @@ def table_summary_atlas(df):
         if key[1] == -1:  # Check if it's a row name cell
             cell.set_text_props(weight='bold')
     plt.show()
+
+def report_network_correspondence(df,atlas_names_list, atlas_names_list_full=None,fig_dir=None):
+    if atlas_names_list_full is None:
+        atlas_names_list_full = atlas_names_list            
+    
+    fig_chart = circular_barchart(df,atlas_names_list,atlas_names_list_full)
+    #save figure
+    #plt.savefig(fig_dir + "/circular_barchart.png", dpi=300, bbox_inches='tight')
+    fig_spider = circular_atlases_all(df,atlas_names_list)
+    #save figure
+    #plt.savefig(fig_dir + "/circular_atlases_all.png", dpi=300, bbox_inches='tight')
+    figs_table = table_summary_plot(df,atlas_names_list,atlas_names_list_full) 
+
+    # save figures if fig_dir is not None
+    if fig_dir is not None:
+        # if directory doesn't exist, create it
+        if not os.path.exists(fig_dir):
+            os.makedirs(fig_dir)
+        fig_chart.savefig(fig_dir + "/circular_barchart.png", dpi=300, bbox_inches='tight')
+        fig_spider.savefig(fig_dir + "/circular_atlases_all.png", dpi=300, bbox_inches='tight')
+        for key in figs_table:
+            figs_table[key].savefig(fig_dir + "/table_summary_plot" + str(key) + ".png", dpi=300, bbox_inches='tight')


### PR DESCRIPTION
## Description

Spin rotation matrices were precomputed to save computation time, however, these files exceeds the github maximum limit (100MB).

These files were compressed and split into multiple parts in cbig_network_correspondence_data. In the toolbox, these sub-files were combined and then decompressed during the import of the toolbox.

We also fixed several bugs to report the results as figures.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
