### PR TITLE
Fix bug: input data will be binarized again when computing pvalue for soft or metric data in MNI 2mm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cbig_network_correspondence"
-version = "0.3.1"
+version = "0.3.2"
 description = "A toolbox for exploring network correspondence across atlases"
 authors = [
     "Ruby Kong <roo.cone@gmail.com>",

--- a/src/cbig_network_correspondence/compute_overlap_with_atlases.py
+++ b/src/cbig_network_correspondence/compute_overlap_with_atlases.py
@@ -529,6 +529,8 @@ def permute_overlap_data_all(data_params, atlas_names):
         #data_params.config.name = "input_data"
         data_path = proj_atlas(data_params)
         data_params.data_path = data_path
+        #the threshold has to set to None, otherwise the threshold will be applied to the projected data, which is already binarized
+        data_params.config.threshold = None
 
     if atlas_names is None:
         # Reads in the atlas in the same space as the data


### PR DESCRIPTION
## Description

We fixed a bug where the input data will be binarized again when computing pvalue for soft or metric data in MNI 2mm

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
