### PR TITLE
Fix pandas deprecation

### DIFF
--- a/src/cbig_network_correspondence/visualize_report_lib.py
+++ b/src/cbig_network_correspondence/visualize_report_lib.py
@@ -472,7 +472,10 @@ def table_summary_singleplot(df,atlas_names,atlas_names_fullname):
         df_all[dice_c] = df_all[dice_c].replace(0,0.0001)
         df_all[dice_c] = df_all[dice_c].fillna(0)
     for p_value_c in p_value_list:
-        df_all[p_value_c] = df_all[p_value_c].fillna(0)
+        df_all[p_value_c] = pd.to_numeric(
+            df_all[p_value_c],
+            errors="coerce"
+        ).fillna(0.0)
 
     col_defs = (
         [ColumnDefinition(

--- a/src/cbig_network_correspondence/visualize_report_lib.py
+++ b/src/cbig_network_correspondence/visualize_report_lib.py
@@ -470,7 +470,10 @@ def table_summary_singleplot(df,atlas_names,atlas_names_fullname):
     for dice_c in dice_list:
         # replace 0 with 0.0001
         df_all[dice_c] = df_all[dice_c].replace(0,0.0001)
-        df_all[dice_c] = df_all[dice_c].fillna(0)
+        df_all[dice_c] = pd.to_numeric(
+            df_all[dice_c],
+            errors="coerce"
+        ).fillna(0.0)
     for p_value_c in p_value_list:
         df_all[p_value_c] = pd.to_numeric(
             df_all[p_value_c],


### PR DESCRIPTION
Executing the corrispondence on a single file we get two warnings for future deprecation:

```
site-packages/cbig_network_correspondence/visualize_report_lib.py:473: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_all[dice_c] = df_all[dice_c].fillna(0)
```

```
site-packages/cbig_network_correspondence/visualize_report_lib.py:475: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_all[p_value_c] = df_all[p_value_c].fillna(0)
```

To prevent those warning I added an explicit conversion to numeric for dice and p_values column
